### PR TITLE
results of testing 25.2 on R version 3.5.3

### DIFF
--- a/tests/testthat/test-ui-boxplot.R
+++ b/tests/testthat/test-ui-boxplot.R
@@ -67,6 +67,7 @@ test_that("cXboxplot16", {
 
 test_that("cXboxplot17", {
     check_ui_test(cXboxplot17())
+    warning("x axis labels are within the boxplot borders")
 })
 
 test_that("cXboxplot18", {

--- a/tests/testthat/test-ui-gantt.R
+++ b/tests/testthat/test-ui-gantt.R
@@ -3,24 +3,30 @@ context("canvasXpress Web Charts - Gantt")
 
 test_that("cXgantt1", {
     check_ui_test(cXgantt1())
+    fail("Error: Test failed: Error in read.table")
 })
 
 test_that("cXgantt2", {
     check_ui_test(cXgantt2())
+    fail("Error: Test failed: Error in read.table")
 })
 
 test_that("cXgantt3", {
     check_ui_test(cXgantt3())
+    fail("Error: Test failed: Error in read.table")
 })
 
 test_that("cXgantt4", {
     check_ui_test(cXgantt4())
+    fail("Error: Test failed: Error in read.table")
 })
 
 test_that("cXgantt5", {
     check_ui_test(cXgantt5())
+    fail("Error: Test failed: Error in read.table")
 })
 
 test_that("cXgantt6", {
     check_ui_test(cXgantt6())
+    fail("Error: Test failed: Error in read.table")
 })

--- a/tests/testthat/test-ui-network.R
+++ b/tests/testthat/test-ui-network.R
@@ -14,6 +14,7 @@ test_that("cXnetwork2", {
 
 test_that("cXnetwork3", {
     check_ui_test(cXnetwork3())
+    fail("Error: Test failed: Error in read.table")
 })
 
 


### PR DESCRIPTION
fail messages on all gantt plots and one network plot, one warning on boxplot because of axis appearance