### PR TITLE
testing 25.3

### DIFF
--- a/tests/testthat/test-ui-chord.R
+++ b/tests/testthat/test-ui-chord.R
@@ -11,4 +11,5 @@ test_that("cXchord2", {
 
 test_that("cXchord3", {
     check_ui_test(cXchord3())
+    warning("when hovering over graph, text is displayed in the plot centre (if plot is not resized)")
 })

--- a/tests/testthat/test-ui-density.R
+++ b/tests/testthat/test-ui-density.R
@@ -31,4 +31,5 @@ test_that("cXdensity7", {
 
 test_that("cXdensity8", {
     check_ui_test(cXdensity8())
+    warning("variable names are different, web example uses var, not V")
 })

--- a/tests/testthat/test-ui-gantt.R
+++ b/tests/testthat/test-ui-gantt.R
@@ -7,25 +7,20 @@ test_that("cXgantt1", {
 
 test_that("cXgantt2", {
     check_ui_test(cXgantt2())
-    warning("background coloring for dependencies field in table is red when null, blue when not null, and in web example, is blue when null and red when not null")
 })
 
 test_that("cXgantt3", {
     check_ui_test(cXgantt3())
-    warning("table colors for dependency field may differ from web example")
 })
 
 test_that("cXgantt4", {
     check_ui_test(cXgantt4())
-    warning("table colors for dependency field may differ from web example")
 })
 
 test_that("cXgantt5", {
     check_ui_test(cXgantt5())
-    warning("table colors for dependency fields may differ from web example")
 })
 
 test_that("cXgantt6", {
     check_ui_test(cXgantt6())
-    warning("table colors for dependency fields may differ from web example")
 })

--- a/tests/testthat/test-ui-gantt.R
+++ b/tests/testthat/test-ui-gantt.R
@@ -7,20 +7,25 @@ test_that("cXgantt1", {
 
 test_that("cXgantt2", {
     check_ui_test(cXgantt2())
+    warning("background coloring for dependencies field in table is red when null, blue when not null, and in web example, is blue when null and red when not null")
 })
 
 test_that("cXgantt3", {
     check_ui_test(cXgantt3())
+    warning("table colors for dependency field may differ from web example")
 })
 
 test_that("cXgantt4", {
     check_ui_test(cXgantt4())
+    warning("table colors for dependency field may differ from web example")
 })
 
 test_that("cXgantt5", {
     check_ui_test(cXgantt5())
+    warning("table colors for dependency fields may differ from web example")
 })
 
 test_that("cXgantt6", {
     check_ui_test(cXgantt6())
+    warning("table colors for dependency fields may differ from web example")
 })


### PR DESCRIPTION
tested all plots up to gantt. a few warnings for colors in the gantt chart tables differing the web example, and warnings for other charts regarding hovering and variable names