### PR TITLE
CircleCI build config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,158 @@
+# Notes:
+# - Docker containers with R, etc. provided by rocker.  See <https://hub.docker.com/r/rocker/verse>.
+# - Builds attempted for 3.6.3, 4.0.5, and the *latest* R edition supported by rocker.
+
+version: 2.1
+jobs:
+  Build-for-r3_6_3:
+    docker:
+      - image: rocker/verse:3.6.3
+
+    steps:
+      - checkout
+      - run:
+          name: Review checkout
+          command: ls -la
+
+      - run:
+          name: Install Linux dependencies
+          command: |
+            sudo apt-get update -y
+            sudo apt-get install -yq texlive-fonts-recommended
+            sudo apt-get install -yq texlive-fonts-extra
+
+      - run:
+          name: Install R dependencies
+          command: |
+            R -e 'install.packages("BiocManager")'
+            R -e 'BiocManager::install(c("limma"))'
+            R -e 'install.packages("covr")'
+            R -e 'install.packages("canvasXpress.data")'
+
+      - run:
+          name: Session information and installed package versions
+          command: |
+            Rscript -e 'sessionInfo()'
+            Rscript -e 'installed.packages()[, c("Package", "Version")]'
+            Rscript -e 'rmarkdown::pandoc_version()'
+
+      - run:
+          name: Build package
+          command: R CMD build .
+
+      - run:
+          name: Check coverage
+          command: Rscript -e 'library(covr); codecov(quiet = FALSE)'
+
+      - run:
+          name: Check package
+          command: |
+            # Install suggested packages
+            R -e 'install.packages("png")'
+            # Perform package check
+            R CMD check *tar.gz
+
+  Build-for-r4_0_5:
+    docker:
+      - image: rocker/verse:4.0.5
+
+    steps:
+      - checkout
+      - run:
+          name: Review checkout
+          command: ls -la
+
+      - run:
+          name: Install Linux dependencies
+          command: |
+            sudo apt-get update -y
+            sudo apt-get install -yq texlive-fonts-recommended
+            sudo apt-get install -yq texlive-fonts-extra
+
+      - run:
+          name: Install R dependencies
+          command: |
+            R -e 'install.packages("BiocManager")'
+            R -e 'BiocManager::install(c("limma"))'
+            R -e 'install.packages("covr")'
+            R -e 'install.packages("canvasXpress.data")'
+
+      - run:
+          name: Session information and installed package versions
+          command: |
+            Rscript -e 'sessionInfo()'
+            Rscript -e 'installed.packages()[, c("Package", "Version")]'
+            Rscript -e 'rmarkdown::pandoc_version()'
+
+      - run:
+          name: Build package
+          command: R CMD build .
+
+      - run:
+          name: Check coverage
+          command: Rscript -e 'library(covr); codecov(quiet = FALSE)'
+
+      - run:
+          name: Check package
+          command: |
+            # Install suggested packages
+            R -e 'install.packages("png")'
+            # Perform package check
+            R CMD check *tar.gz
+
+
+  Build-for-rLATEST:
+    docker:
+      - image: rocker/verse:latest
+
+    steps:
+      - checkout
+      - run:
+          name: Review checkout
+          command: ls -la
+
+      - run:
+          name: Install Linux dependencies
+          command: |
+            sudo apt-get update -y
+            sudo apt-get install -yq texlive-fonts-recommended
+            sudo apt-get install -yq texlive-fonts-extra
+
+      - run:
+          name: Install R dependencies
+          command: |
+            R -e 'install.packages("BiocManager")'
+            R -e 'BiocManager::install(c("limma"))'
+            R -e 'install.packages("covr")'
+            R -e 'install.packages("canvasXpress.data")'
+
+      - run:
+          name: Session information and installed package versions
+          command: |
+            Rscript -e 'sessionInfo()'
+            Rscript -e 'installed.packages()[, c("Package", "Version")]'
+            Rscript -e 'rmarkdown::pandoc_version()'
+
+      - run:
+          name: Build package
+          command: R CMD build .
+
+      - run:
+          name: Check coverage
+          command: Rscript -e 'library(covr); codecov(quiet = FALSE)'
+
+      - run:
+          name: Check package
+          command: |
+            # Install suggested packages
+            R -e 'install.packages("png")'
+            # Perform package check
+            R CMD check *tar.gz
+
+workflows:
+  version: 2
+  Prepare-All-R-Editions:
+    jobs:
+      - Build-for-r4_0_5
+      - Build-for-r3_6_3
+      - Build-for-rLATEST


### PR DESCRIPTION
The intent is to enable build support by CircleCI for this R package.  The proposed change involves:

1. The addition of a `.circleci` directory at the project root
2. The addition of a `config.yml` in the `.circleci` directory
3. CircleCI instructions within the config file for building, testing, and checking the R package.

This change should have no effect from the perspective of development workstations or alternate build engines/portals.  This change has been successfully tested using my CircleCI account.