### PR TITLE
Adding in a CX shiny example showing an event capture

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,6 +30,7 @@ Suggests:
     shiny (>= 1.1.0),
     canvasXpress.data,
     dplyr,
+    DT,
     glue,
     grid,
     knitr,

--- a/inst/shiny-examples/example_events/server.R
+++ b/inst/shiny-examples/example_events/server.R
@@ -1,0 +1,59 @@
+library(shiny)
+library(canvasXpress)
+library(dplyr)
+library(DT)
+library(stats)
+
+
+shinyServer(function(input, output, session) {
+  y <- matrix(runif(n = 150), nrow = 10) %>%
+    as.data.frame()
+  colnames(y) <- paste0("S", 1:15)
+  rownames(y) <- paste0("V", 1:10)
+
+  capture_click_ex <- htmlwidgets::JS(
+    "{'dblclick': function(o, e, t) {
+        t.masterReset();
+                if (o != null) {
+                    Shiny.onInputChange('clicked_cell', o.y);
+    }
+    }}"
+  )
+
+  output$genelist_heatmap <- canvasXpress::renderCanvasXpress({
+    canvasXpress(
+      data = t(y),
+      colorSpectrum = list("navy", "white", "firebrick3"),
+      graphType = "Heatmap",
+      events = capture_click_ex
+    )
+  })
+
+  output$y <- renderDT({
+    if (isTruthy(input$clicked_cell)) {
+      y$col <- as.numeric(
+        input$clicked_cell$smps[[1]] == rownames(y)
+      )
+      datatable(y,
+        options = list(
+          columnDefs = list(list(
+            visible = FALSE,
+            targets = c(ncol(y))
+          ))
+        )
+      ) %>%
+        formatStyle(
+          columns = input$clicked_cell$vars[[1]],
+          valueColumns = "col",
+          backgroundColor = styleEqual(
+            c(0, 1),
+            c("white", "yellow")
+          )
+        ) %>%
+        formatSignif(1:ncol(y), digits = 3)
+    } else {
+      datatable(y) %>%
+        formatSignif(1:ncol(y), digits = 3)
+    }
+  })
+})

--- a/inst/shiny-examples/example_events/ui.R
+++ b/inst/shiny-examples/example_events/ui.R
@@ -1,0 +1,16 @@
+library(shiny)
+library(canvasXpress)
+library(DT)
+
+
+shinyUI(
+  fluidPage(
+    h1("CX events heatmap example"),
+    h3("Double click heatmap cell to highlight table cell"),
+    canvasXpress::canvasXpressOutput("genelist_heatmap",
+      width = "100%",
+      height = "250px"
+    ),
+    DTOutput("y")
+  )
+)

--- a/tests/testthat/Rplots.pdf
+++ b/tests/testthat/Rplots.pdf
@@ -1,0 +1,17 @@
+%PDF-1.4
+%Å‚Å„ÅœÅ”\r
+1 0 obj
+<<
+/CreationDate (D:20230602175147)
+/ModDate (D:20230602175147)
+/Title (R Graphics Output)
+/Producer (R 4.2.2)
+/Creator (R)
+>>
+endobj
+2 0 obj
+<< /Type /Catalog /Pages 3 0 R >>
+endobj
+7 0 obj
+<< /Type /Page /Parent 3 0 R /Contents 8 0 R /Resources 4 0 R >>
+endobj

--- a/tests/testthat/test-other--BASE.R
+++ b/tests/testthat/test-other--BASE.R
@@ -82,9 +82,9 @@ test_that("Shiny Render", {
 
 test_that("Shiny Examples", {
     expect_error(cxShinyExample("badexample"),
-                 regexp = "Valid examples are: 'example1', 'example2', 'example3'")
+                 regexp = "Valid examples are: 'example_events', 'example1', 'example2', 'example3'")
     expect_message(cxShinyExample(NULL),
-                 regexp = "Valid examples are: 'example1', 'example2', 'example3'")
+                 regexp = "Valid examples are: 'example_events', 'example1', 'example2', 'example3'")
 })
 
 


### PR DESCRIPTION
Specifically this example shows how to capture a double clicked event from a CX heatmap.

I followed the steps already used for examples1/2/3, and edited appropriate unit tests.